### PR TITLE
Abn langdetect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Ice-g2p : Phonetic transcription (grapheme-to-phoneme) for Icelandic
 
-Ice-g2p is a module for automatic phonetic transcription of Icelandic.
+Ice-g2p is a module for automatic phonetic transcription of Icelandic. Ice-g2p can be used as a stand-alone
+command line tool or as a library, and can e.g. be used for the final text processing step in a frontend
+pipeline for speech synthesis (TTS).
+
+Ice-g2p uses a manually curated [pronunciation dictionary](https://github.com/grammatek/iceprondict)
+and LSTM-based [g2p-models](https://github.com/grammatek/g2p-lstm) for unknown words. It can be used
+to transcribe Icelandic in four pronunciation variations and also uses a special model to transcribe
+English words that might occur in Icelandic texts, using the Icelandic phone set.
 
 ## Setup
 
@@ -22,8 +29,13 @@ Characters allowed: _[aábcðdeéfghiíjklmnoóprstuúvxyýzþæö]_. If other c
 
 To transcribe text, currently two main options are available, direct from stdin to stdout or from file or a collection of files (directory) 
 
-    %python src/ice-g2p/main.py -i 'hljóðrita þetta takk'
+    $ python3 src/ice-g2p/main.py -i 'hljóðrita þetta takk'
 	l_0 j ou D r I t a T E h t a t_h a h k
+
+    $ python3 src/ice-g2p/main.py -i 'þetta war fürir þig'
+    war contains non valid character(s) {'w'}, skipping transcription.
+    fürir contains non valid character(s) {'ü'}, skipping transcription.
+    T E h t a   T I: G
 
 	%python src/ice-g2p/main.py -if file_to_transcribe.txt
 

--- a/src/ice_g2p/g2p_lstm.py
+++ b/src/ice_g2p/g2p_lstm.py
@@ -60,6 +60,8 @@ class FairseqG2P:
         """
         transcribed_arr = []
         for wrd in text.split(' '):
+            if not wrd:
+                continue
             # start with lookup
             transcr = ''
             if use_dict and self.custom_dict:

--- a/test/g2p_lstm_test.py
+++ b/test/g2p_lstm_test.py
@@ -43,11 +43,18 @@ class TestG2P_LSTM(unittest.TestCase):
         transcribed = g2p.transcribe(test_string)
         self.assertEqual('l_0 9i:1 - p_h a0 - i:1 - p Y1 r_0 - t Y0 - l_0 9i:1 - p_h a0 - s t r au0 - k_h Y0 r', transcribed)
 
+    def test_double_space(self):
+        test_string = 'takk fyrir jóhanna .  góðan dag góðir gestir .'
+        g2p = Transcriber()
+        transcribed = g2p.transcribe(test_string)
+        self.assertEqual('t_h a h k f I: r I r j ou: h a n a   k ou: D a n t a: G k ou: D I r c E s t I r ', transcribed)
+
+
     def test_english(self):
         test_string = 'what ertu crazy'
         g2p = Transcriber(dialect='north', use_dict=True, lang_detect=True, syllab_symbol='-', word_sep='-', stress_label=True)
         transcribed = g2p.transcribe(test_string)
-        self.assertEqual('v a1 h t - E1 r_0 - t Y0 - k_h r ei:1 - s i0', transcribed)
+        self.assertEqual('v O1 t - E1 r_0 - t Y0 - k_h r ei:1 - s i0', transcribed)
 
 
     def test_cmu_format(self):


### PR DESCRIPTION
fix: empty string transcribed as 'j E:'; prevent empty string from going into the lstm model at all