### PR TITLE
Disable fairseq INFO logs when using g2p

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 dist/
 **/**.egg-info
 build/
+**/**/__pycache__/
+fairseq_models/

--- a/src/ice_g2p/g2p_lstm.py
+++ b/src/ice_g2p/g2p_lstm.py
@@ -4,7 +4,9 @@
 """
 
 import os
+import logging
 from fairseq.models.transformer import TransformerModel
+logging.getLogger('fairseq').setLevel(logging.WARNING)
 
 # if word separation is required in transcribed output
 # use this separator


### PR DESCRIPTION
This PR removes the info logs that clutter the command line when using ice-g2p.
The log level is set to WARNING so important logs will still be printed.