### PR TITLE
compound analysis

### DIFF
--- a/src/ice_g2p/compound_analysis.py
+++ b/src/ice_g2p/compound_analysis.py
@@ -1,0 +1,32 @@
+"""
+Decomposes compound words on a grapheme basis to prepare for automatic transcription.
+"""
+
+from ice_g2p import tree_builder
+from ice_g2p import entry
+
+
+def get_compound_parts(token: str) -> list:
+    """ Decomposes 'token' if it is a compound.
+    Returns a list of the components, or a single element list containing 'token'
+    if no decomposition can be performed. """
+
+    token_entry = entry.PronDictEntry(word=token)
+    compound_tree = tree_builder.build_compound_tree_token_only(token_entry)
+    result_arr = []
+    decompose(compound_tree, result_arr)
+    return result_arr
+
+
+def decompose(entry_tree: tree_builder.CompoundTree, token_arr: list):
+    """ Recursively call decompose on each element of entry_tree.
+    Collects found compound elements as strings in 'token_arr'.
+    """
+    if not entry_tree.left:
+        token_arr.append(entry_tree.elem.word)
+    if entry_tree.left:
+        decompose(entry_tree.left, token_arr)
+    if entry_tree.right:
+        decompose(entry_tree.right, token_arr)
+
+

--- a/src/ice_g2p/tree_builder.py
+++ b/src/ice_g2p/tree_builder.py
@@ -154,13 +154,44 @@ def extract_compound_components(comp_tree):
             extract_compound_components(right_tree)
 
 
+def extract_compound_components_token_only(comp_tree):
+    """
+    As long as compound components can be extracted, extract compound components recursively.
+
+    :param comp_tree: a tree containing one root element. If compound components are found, they are added
+    as children of the root.
+    :return:
+    """
+    mod, head = lookup_compound_components(comp_tree.elem.word)
+    if len(mod) > 0 and len(head) > 0:
+        left_elem = entry.PronDictEntry(word=mod)
+        left_tree = CompoundTree(left_elem)
+        comp_tree.left = left_tree
+        right_elem = entry.PronDictEntry(word=head)
+        right_tree = CompoundTree(right_elem)
+        comp_tree.right = right_tree
+        extract_compound_components_token_only(left_tree)
+        extract_compound_components_token_only(right_tree)
+
+
 def build_compound_tree(entry):
     """
-    :param entry: a PronDictEntry
+    :param entry: a PronDictEntry with transcription
     :return: a binary tree based on compound division
     """
 
     comp_tree = CompoundTree(entry)
     extract_compound_components(comp_tree)
+    return comp_tree
+
+
+def build_compound_tree_token_only(entry):
+    """
+    :param entry: a PronDictEntry, not necessarily containing a transcription
+    :return: a binary tree based on compound division
+    """
+
+    comp_tree = CompoundTree(entry)
+    extract_compound_components_token_only(comp_tree)
     return comp_tree
 

--- a/test/compound_test.py
+++ b/test/compound_test.py
@@ -1,0 +1,22 @@
+import unittest
+from ice_g2p import compound_analysis
+
+
+class CompoundTestCase(unittest.TestCase):
+    def test_valid_compound(self):
+        comp = 'föðurafi'
+        comp_parts = compound_analysis.get_compound_parts(comp)
+        self.assertEqual(['föður', 'afi'], comp_parts)
+
+        comp = 'djasstónlistarkennsla'
+        comp_parts = compound_analysis.get_compound_parts(comp)
+        self.assertEqual(['djass', 'tón', 'listar', 'kennsla'], comp_parts)
+
+    def test_non_compound(self):
+        comp = 'föður'
+        comp_parts = compound_analysis.get_compound_parts(comp)
+        self.assertEqual(['föður'], comp_parts)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/g2p_lstm_test.py
+++ b/test/g2p_lstm_test.py
@@ -64,7 +64,7 @@ class TestG2P_LSTM(unittest.TestCase):
         # input_str: str, icelandic=True, syllab=False, use_dict=False, word_sep: str=None, cmu=False
         transcribed = g2p.transcribe(test_string, cmu=True)
         print(transcribed)
-        self.assertEqual('("hljóðritaður" nil (((l_0 j ou D ) 1) ((r I ) 0) ((t a ) 0) ((D Y r ) 0))) ("texti" nil (((t_h E k s ) 1) ((t I ) 0)))', transcribed)
+        self.assertEqual('("hljóðritaður" nil (((l_0 j ou: D ) 1) ((r I ) 0) ((t a ) 0) ((D Y r ) 0))) ("texti" nil (((t_h E k s ) 1) ((t I ) 0)))', transcribed)
 
     def test_custom_dict(self):
         custom_dict = self.get_custom_dict()


### PR DESCRIPTION
Compound analysis now also done on grapheme basis before automatic transcription.
Each compound component is transcribed individually and the results joined. Note that we follow the rule from the pronunciation dictionary that a vowel can only be long in the first syllable of a word, even in a long compound.